### PR TITLE
chore: package name and regenerate package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@minhtetoo/tradetrust-core",
-  "version": "1.0.28",
+  "name": "@tradetrust-tt/tradetrust-core",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@minhtetoo/tradetrust-core",
-      "version": "1.0.28",
+      "name": "@tradetrust-tt/tradetrust-core",
+      "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
         "@tradetrust-tt/document-store": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradetrust-tt/tradetrust-core",
-  "version": "1.0.6",
+  "version": "0.0.0",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION

## Summary

fixed the mistake in package name and set version to 0.0.0. the actual version for npm release doesn't depend upon the version in package.json

## Changes

- change version to 0.0.0 as npm package release doesn't depend on it
- fix the package name
