### PR TITLE
fix: update tt-verify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@tradetrust-tt/document-store": "^4.0.0",
         "@tradetrust-tt/token-registry": "^4.10.2",
         "@tradetrust-tt/tradetrust": "^6.9.5",
-        "@tradetrust-tt/tt-verify": "^8.9.2",
+        "@tradetrust-tt/tt-verify": "^8.9.4",
         "dotenv": "^16.4.5",
         "node-fetch": "^2.6.1"
       },
@@ -1169,101 +1169,6 @@
         "node-fetch": "^2.6.12"
       }
     },
-    "node_modules/@govtechsg/oa-did-sign": {
-      "version": "2.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@govtechsg/open-attestation": "^4.5.0",
-        "did-resolver": "^2.1.1",
-        "ethers": "^5.0.4",
-        "ethr-did-resolver": "^3.0.0",
-        "node-cache": "^5.1.2",
-        "snyk": "^1.406.0",
-        "web-did-resolver": "^1.3.3"
-      }
-    },
-    "node_modules/@govtechsg/oa-did-sign/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/@govtechsg/oa-did-sign/node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
-    "node_modules/@govtechsg/oa-did-sign/node_modules/did-resolver": {
-      "version": "2.2.0",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@govtechsg/oa-did-sign/node_modules/ethr-did-resolver": {
-      "version": "3.0.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "buffer": "^6.0.0",
-        "did-resolver": "2.1.2",
-        "elliptic": "^6.5.3",
-        "ethjs-abi": "^0.2.1",
-        "ethjs-contract": "^0.2.0",
-        "ethjs-provider-http": "^0.1.6",
-        "ethjs-query": "^0.3.5",
-        "ethr-did-registry": "^0.0.3",
-        "js-sha3": "^0.8.0"
-      }
-    },
-    "node_modules/@govtechsg/oa-did-sign/node_modules/ethr-did-resolver/node_modules/did-resolver": {
-      "version": "2.1.2",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@govtechsg/oa-did-sign/node_modules/ieee754": {
-      "version": "1.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@govtechsg/oa-did-sign/node_modules/web-did-resolver": {
-      "version": "1.3.5",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "cross-fetch": "^3.0.4",
-        "did-resolver": "2.1.1"
-      }
-    },
-    "node_modules/@govtechsg/oa-did-sign/node_modules/web-did-resolver/node_modules/did-resolver": {
-      "version": "2.1.1",
-      "license": "Apache-2.0"
-    },
     "node_modules/@govtechsg/oa-encryption": {
       "version": "1.3.5",
       "dev": true,
@@ -1272,151 +1177,6 @@
         "debug": "4.3.4",
         "node-forge": "1.3.1"
       }
-    },
-    "node_modules/@govtechsg/open-attestation": {
-      "version": "4.7.3",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ajv": "6.10.2",
-        "debug": "^4.1.1",
-        "did-resolver": "^2.1.2",
-        "ethers": "^5.0.31",
-        "ethr-did-resolver": "^3.0.3",
-        "flatley": "^5.2.0",
-        "js-base64": "^2.5.2",
-        "js-sha3": "^0.8.0",
-        "jsonld": "^3.1.0",
-        "lodash": "^4.17.15",
-        "node-fetch": "^2.6.0",
-        "runtypes": "^5.0.1",
-        "uuid": "^3.3.3",
-        "validator": "^12.0.0",
-        "verbal-expressions": "^1.0.2",
-        "web-did-resolver": "^1.3.5"
-      }
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/ajv": {
-      "version": "6.10.2",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/did-resolver": {
-      "version": "2.2.0",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/ethr-did-resolver": {
-      "version": "3.0.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "buffer": "^6.0.0",
-        "did-resolver": "2.1.2",
-        "elliptic": "^6.5.3",
-        "ethjs-abi": "^0.2.1",
-        "ethjs-contract": "^0.2.0",
-        "ethjs-provider-http": "^0.1.6",
-        "ethjs-query": "^0.3.5",
-        "ethr-did-registry": "^0.0.3",
-        "js-sha3": "^0.8.0"
-      }
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/ethr-did-resolver/node_modules/did-resolver": {
-      "version": "2.1.2",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "license": "MIT"
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/ieee754": {
-      "version": "1.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/js-base64": {
-      "version": "2.6.4",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/runtypes": {
-      "version": "5.1.0",
-      "license": "MIT"
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/uuid": {
-      "version": "3.4.0",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/validator": {
-      "version": "12.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/web-did-resolver": {
-      "version": "1.3.5",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "cross-fetch": "^3.0.4",
-        "did-resolver": "2.1.1"
-      }
-    },
-    "node_modules/@govtechsg/open-attestation/node_modules/web-did-resolver/node_modules/did-resolver": {
-      "version": "2.1.1",
-      "license": "Apache-2.0"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -1911,46 +1671,6 @@
         "@scure/base": "~1.1.0"
       }
     },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.116.0",
-        "@sentry/types": "7.116.0",
-        "@sentry/utils": "7.116.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry-internal/tracing/node_modules/@sentry/core": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.116.0",
-        "@sentry/utils": "7.116.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.116.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@sentry/core": {
       "version": "5.30.0",
       "dev": true,
@@ -1977,47 +1697,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/integrations": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.116.0",
-        "@sentry/types": "7.116.0",
-        "@sentry/utils": "7.116.0",
-        "localforage": "^1.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/integrations/node_modules/@sentry/core": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.116.0",
-        "@sentry/utils": "7.116.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/integrations/node_modules/@sentry/types": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/integrations/node_modules/@sentry/utils": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.116.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@sentry/minimal": {
@@ -2104,8 +1783,9 @@
       }
     },
     "node_modules/@tradetrust-tt/dnsprove": {
-      "version": "2.12.3",
-      "license": "Apache-2.0",
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/dnsprove/-/dnsprove-2.12.4.tgz",
+      "integrity": "sha512-tE/AbXe26bAK0xm+boxzUqmrKfV+Iy48a/dJbfroZXf3OmKYTAOeXU20zfnvSzK24Nzl6n/PAkkrg73mcdjuhw==",
       "dependencies": {
         "axios": "0.21.1",
         "debug": "^4.3.1",
@@ -2214,11 +1894,11 @@
       "license": "MIT"
     },
     "node_modules/@tradetrust-tt/tt-verify": {
-      "version": "8.9.2",
-      "license": "Apache-2.0",
+      "version": "8.9.4",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/tt-verify/-/tt-verify-8.9.4.tgz",
+      "integrity": "sha512-ojHnnG4w2XCjAKt0wFKk9kjaRCd6122Qs68oSt/Jvb7pl87yScw7nh/ChpTvpC8j+88mZdukXst4wIIHOoRllA==",
       "dependencies": {
-        "@govtechsg/oa-did-sign": "^2.2.0",
-        "@tradetrust-tt/dnsprove": "^2.12.3",
+        "@tradetrust-tt/dnsprove": "^2.12.4",
         "@tradetrust-tt/document-store": "^2.7.0",
         "@tradetrust-tt/token-registry": "^4.9.0",
         "@tradetrust-tt/tradetrust": "^6.9.0",
@@ -2876,6 +2556,7 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.5",
@@ -2903,6 +2584,7 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -2921,13 +2603,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "node_modules/asn1.js": {
       "version": "5.4.1",
       "dev": true,
@@ -2943,13 +2618,6 @@
       "version": "4.12.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -2973,6 +2641,7 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -3013,35 +2682,12 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.0",
-      "license": "MIT"
-    },
     "node_modules/axios": {
       "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.10.0"
       }
-    },
-    "node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3057,6 +2703,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3072,17 +2719,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "license": "Unlicense"
     },
     "node_modules/bech32": {
       "version": "1.1.4",
@@ -3139,10 +2775,6 @@
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
-      "license": "MIT"
-    },
-    "node_modules/boolean": {
-      "version": "3.2.0",
       "license": "MIT"
     },
     "node_modules/boxen": {
@@ -3271,6 +2903,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -3307,10 +2940,6 @@
     },
     "node_modules/canonicalize": {
       "version": "1.0.8",
-      "license": "Apache-2.0"
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
       "license": "Apache-2.0"
     },
     "node_modules/chai": {
@@ -3472,7 +3101,8 @@
     },
     "node_modules/clone": {
       "version": "2.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "engines": {
         "node": ">=0.8"
       }
@@ -3792,15 +3422,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
       "dev": true,
@@ -3988,16 +3609,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "dev": true,
@@ -4012,6 +3623,7 @@
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.6",
@@ -4027,6 +3639,7 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -4042,6 +3655,7 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.6",
@@ -4151,6 +3765,7 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -4166,6 +3781,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -4209,10 +3825,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "license": "MIT"
     },
     "node_modules/did-resolver": {
       "version": "3.2.2",
@@ -4275,14 +3887,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/elliptic": {
@@ -4348,6 +3952,7 @@
     },
     "node_modules/es-abstract": {
       "version": "1.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -4406,6 +4011,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.4"
@@ -4416,6 +4022,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4423,6 +4030,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4433,6 +4041,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.4",
@@ -4445,6 +4054,7 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -4457,10 +4067,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.20.2",
@@ -4509,6 +4115,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4853,155 +4460,6 @@
         "node": ">= 10.18"
       }
     },
-    "node_modules/ethjs-abi": {
-      "version": "0.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "4.11.6",
-        "js-sha3": "0.5.5",
-        "number-to-bn": "1.7.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-abi/node_modules/bn.js": {
-      "version": "4.11.6",
-      "license": "MIT"
-    },
-    "node_modules/ethjs-abi/node_modules/js-sha3": {
-      "version": "0.5.5",
-      "license": "MIT"
-    },
-    "node_modules/ethjs-contract": {
-      "version": "0.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "ethjs-abi": "0.2.0",
-        "ethjs-filter": "0.1.8",
-        "ethjs-util": "0.1.3",
-        "js-sha3": "0.5.5"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-contract/node_modules/bn.js": {
-      "version": "4.11.6",
-      "license": "MIT"
-    },
-    "node_modules/ethjs-contract/node_modules/ethjs-abi": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "4.11.6",
-        "js-sha3": "0.5.5",
-        "number-to-bn": "1.7.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-contract/node_modules/ethjs-util": {
-      "version": "0.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-contract/node_modules/js-sha3": {
-      "version": "0.5.5",
-      "license": "MIT"
-    },
-    "node_modules/ethjs-filter": {
-      "version": "0.1.8",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-format": {
-      "version": "0.2.7",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "4.11.6",
-        "ethjs-schema": "0.2.1",
-        "ethjs-util": "0.1.3",
-        "is-hex-prefixed": "1.0.0",
-        "number-to-bn": "1.7.0",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-format/node_modules/bn.js": {
-      "version": "4.11.6",
-      "license": "MIT"
-    },
-    "node_modules/ethjs-format/node_modules/ethjs-util": {
-      "version": "0.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-provider-http": {
-      "version": "0.1.6",
-      "license": "MIT",
-      "dependencies": {
-        "xhr2": "0.1.3"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-query": {
-      "version": "0.3.8",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "ethjs-format": "0.2.7",
-        "ethjs-rpc": "0.2.0",
-        "promise-to-callback": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-rpc": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "promise-to-callback": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
-    "node_modules/ethjs-schema": {
-      "version": "0.2.1",
-      "license": "MIT"
-    },
     "node_modules/ethjs-unit": {
       "version": "0.1.6",
       "dev": true,
@@ -5147,10 +4605,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "dev": true,
@@ -5163,13 +4617,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5203,6 +4650,7 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -5369,16 +4817,10 @@
     },
     "node_modules/for-each": {
       "version": "0.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/form-data": {
@@ -5430,6 +4872,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5437,6 +4880,7 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -5453,6 +4897,7 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5476,6 +4921,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5504,6 +4950,7 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.5",
@@ -5515,13 +4962,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/glob": {
@@ -5572,21 +5012,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/global-agent": {
-      "version": "3.0.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "es6-error": "^4.1.1",
-        "matcher": "^3.0.0",
-        "roarr": "^2.15.3",
-        "semver": "^7.3.2",
-        "serialize-error": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=10.0"
       }
     },
     "node_modules/global-directory": {
@@ -5664,6 +5089,7 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -5697,6 +5123,7 @@
     },
     "node_modules/gopd": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
@@ -5712,42 +5139,6 @@
     "node_modules/graphemer": {
       "version": "1.4.0",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/har-validator/node_modules/ajv": {
-      "version": "6.12.6",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/har-validator/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
       "license": "MIT"
     },
     "node_modules/hardhat": {
@@ -6018,6 +5409,7 @@
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6032,6 +5424,7 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -6042,6 +5435,7 @@
     },
     "node_modules/has-proto": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6052,6 +5446,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6062,6 +5457,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6096,6 +5492,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6191,19 +5588,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "dev": true,
@@ -6247,10 +5631,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "license": "MIT"
     },
     "node_modules/immutable": {
       "version": "4.3.6",
@@ -6380,6 +5760,7 @@
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6423,6 +5804,7 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6442,6 +5824,7 @@
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
@@ -6463,6 +5846,7 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6481,6 +5865,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6491,6 +5876,7 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-typed-array": "^1.1.13"
@@ -6504,6 +5890,7 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -6518,13 +5905,6 @@
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fn": {
-      "version": "1.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6565,6 +5945,7 @@
     },
     "node_modules/is-hex-prefixed": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.5.0",
@@ -6581,6 +5962,7 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6599,6 +5981,7 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -6641,6 +6024,7 @@
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6655,6 +6039,7 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7"
@@ -6679,6 +6064,7 @@
     },
     "node_modules/is-string": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -6692,6 +6078,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -6705,6 +6092,7 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.14"
@@ -6715,10 +6103,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -6738,6 +6122,7 @@
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -6763,10 +6148,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6855,10 +6236,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "24.1.0",
@@ -6958,10 +6335,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "license": "MIT"
@@ -6970,10 +6343,6 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "license": "ISC"
     },
     "node_modules/jsonc-parser": {
       "version": "3.2.1",
@@ -6989,64 +6358,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonld": {
-      "version": "3.3.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "canonicalize": "^1.0.1",
-        "lru-cache": "^5.1.1",
-        "object.fromentries": "^2.0.2",
-        "rdf-canonize": "^2.0.1",
-        "request": "^2.88.0",
-        "semver": "^6.3.0",
-        "xmldom": "0.1.19"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jsonld/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/jsonld/node_modules/rdf-canonize": {
-      "version": "2.0.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "semver": "^6.3.0",
-        "setimmediate": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jsonld/node_modules/semver": {
-      "version": "6.3.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/jsonld/node_modules/yallist": {
-      "version": "3.1.1",
-      "license": "ISC"
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/junk": {
@@ -7097,13 +6408,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lie": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -7159,13 +6463,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/localforage": {
-      "version": "1.10.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -7311,16 +6608,6 @@
       },
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/matcher": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/md5.js": {
@@ -7664,7 +6951,8 @@
     },
     "node_modules/node-cache": {
       "version": "5.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
       "dependencies": {
         "clone": "2.x"
       },
@@ -7951,6 +7239,7 @@
     },
     "node_modules/number-to-bn": {
       "version": "1.7.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bn.js": "4.11.6",
@@ -7963,6 +7252,7 @@
     },
     "node_modules/number-to-bn/node_modules/bn.js": {
       "version": "4.11.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nwsapi": {
@@ -7970,15 +7260,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7986,6 +7270,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7993,28 +7278,13 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.fromentries": {
-      "version": "2.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8257,10 +7527,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.0.1",
       "dev": true,
@@ -8373,6 +7639,7 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8451,23 +7718,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/promise-to-callback": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-fn": "^1.0.0",
-        "set-immediate-shim": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.9.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -8484,13 +7741,6 @@
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.3",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/querystring": {
@@ -8634,6 +7884,7 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.6",
@@ -8646,65 +7897,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-directory": {
@@ -8814,21 +8006,6 @@
         "rlp": "bin/rlp"
       }
     },
-    "node_modules/roarr": {
-      "version": "2.15.4",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boolean": "^3.0.1",
-        "detect-node": "^2.0.4",
-        "globalthis": "^1.0.1",
-        "json-stringify-safe": "^5.0.1",
-        "semver-compare": "^1.0.0",
-        "sprintf-js": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.18.0",
       "dev": true,
@@ -8915,6 +8092,7 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -8931,10 +8109,12 @@
     },
     "node_modules/safe-array-concat/node_modules/isarray": {
       "version": "2.0.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8953,6 +8133,7 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.6",
@@ -8968,6 +8149,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -9006,39 +8188,13 @@
     },
     "node_modules/semver": {
       "version": "7.6.2",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/serialize-error": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "0.13.1",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-javascript": {
@@ -9051,6 +8207,7 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -9066,6 +8223,7 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -9075,13 +8233,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-immediate-shim": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/setimmediate": {
@@ -9161,6 +8312,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -9294,63 +8446,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/snyk": {
-      "version": "1.1291.1",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sentry/node": "^7.36.0",
-        "global-agent": "^3.0.0"
-      },
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/snyk/node_modules/@sentry/core": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.116.0",
-        "@sentry/utils": "7.116.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/snyk/node_modules/@sentry/node": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.116.0",
-        "@sentry/core": "7.116.0",
-        "@sentry/integrations": "7.116.0",
-        "@sentry/types": "7.116.0",
-        "@sentry/utils": "7.116.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/snyk/node_modules/@sentry/types": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/snyk/node_modules/@sentry/utils": {
-      "version": "7.116.0",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.116.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/solc": {
       "version": "0.7.3",
       "dev": true,
@@ -9470,37 +8565,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sshpk/node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "license": "Unlicense"
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "dev": true,
@@ -9583,6 +8647,7 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -9599,6 +8664,7 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -9611,6 +8677,7 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -9656,6 +8723,7 @@
     },
     "node_modules/strip-hex-prefix": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0"
@@ -9930,16 +8998,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "dev": true,
@@ -10087,6 +9145,7 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -10099,6 +9158,7 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -10116,6 +9176,7 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -10134,6 +9195,7 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -10196,6 +9258,7 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -10316,25 +9379,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/verbal-expressions": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=9.2.0"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/vite": {
@@ -10648,6 +9692,7 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",
@@ -10662,6 +9707,7 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.15",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -10775,13 +9821,6 @@
         }
       }
     },
-    "node_modules/xhr2": {
-      "version": "0.1.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "dev": true,
@@ -10814,12 +9853,6 @@
       "version": "2.2.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/xmldom": {
-      "version": "0.1.19",
-      "engines": {
-        "node": ">=0.1"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@tradetrust-tt/document-store": "^4.0.0",
     "@tradetrust-tt/token-registry": "^4.10.2",
     "@tradetrust-tt/tradetrust": "^6.9.5",
-    "@tradetrust-tt/tt-verify": "^8.9.2",
+    "@tradetrust-tt/tt-verify": "^8.9.4",
     "dotenv": "^16.4.5",
     "node-fetch": "^2.6.1"
   },


### PR DESCRIPTION
## Summary

there are minor updates on tt-verify to fix the issue of hedera documents being unable to verify with dns-txt record net=ethereum

## Changes

- update tt-verify version to latest

